### PR TITLE
Reimplement Google OAuth using GSI client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1838,6 +1838,24 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "@maxim_mazurok/gapi.client.discovery-v1": {
+      "version": "0.0.20200806",
+      "resolved": "https://registry.npmjs.org/@maxim_mazurok/gapi.client.discovery-v1/-/gapi.client.discovery-v1-0.0.20200806.tgz",
+      "integrity": "sha512-0pZtrElj8bc0YROIo7nH8VVvks/iww/L68l7r74oC9+ksSVO3Lum1zUR8dXTvJ7TqLGaNYiiNaUZianK6doh/w==",
+      "requires": {
+        "@types/gapi.client": "*",
+        "@types/gapi.client.discovery": "*"
+      }
+    },
+    "@maxim_mazurok/gapi.client.oauth2-v2": {
+      "version": "0.0.20200213",
+      "resolved": "https://registry.npmjs.org/@maxim_mazurok/gapi.client.oauth2-v2/-/gapi.client.oauth2-v2-0.0.20200213.tgz",
+      "integrity": "sha512-CtMeicnExqTAoAok72PqqknL1p2sLVbAqB/4rpsbi2LYPy26ln23W+mZUB9uYl6Rt7a0DCqJdohdF40Q/dZv/w==",
+      "requires": {
+        "@types/gapi.client": "*",
+        "@types/gapi.client.discovery": "*"
+      }
+    },
     "@ngtools/webpack": {
       "version": "14.2.5",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-14.2.5.tgz",
@@ -2066,6 +2084,39 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/gapi.client": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gapi.client/-/gapi.client-1.0.5.tgz",
+      "integrity": "sha512-OTpbBMuzfC4lkvaomxqskI/iWRGW3zOZbDXZLNSyiuswTiSSGgILRLkg0POuZ4EgzEdaYaTlXpnXiCp07ri/Yw=="
+    },
+    "@types/gapi.client.discovery": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/gapi.client.discovery/-/gapi.client.discovery-1.0.9.tgz",
+      "integrity": "sha512-51fXpt7DM7+zPG5pgwnNr3KaRXmyszznu66VPpV7+FAu0LGtpTohvdfvkRCnCn2Z6EgNTq/baFAtCa/9ylHOug==",
+      "requires": {
+        "@maxim_mazurok/gapi.client.discovery-v1": "^0.0.20200806"
+      }
+    },
+    "@types/gapi.client.oauth2": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/gapi.client.oauth2/-/gapi.client.oauth2-2.0.4.tgz",
+      "integrity": "sha512-Fdm3aA/crBikPGqLRnUnOmMBi37IW8Ww227I8pMEm7scdWu98cYy2BMyP9dmMWrE8JuwmSBUwkUbcrPjNTXG3A==",
+      "requires": {
+        "@maxim_mazurok/gapi.client.oauth2-v2": "^0.0.20200213"
+      }
+    },
+    "@types/google-one-tap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/google-one-tap/-/google-one-tap-1.2.2.tgz",
+      "integrity": "sha512-7uAOjukbJnzJ5P8fKPSy7QDrbLbCEyUrSH/M4K+8wnk+cbSxE3t2MmrLPX7ejUl8rDZv3oUl0/uwQRlIIrLMBA==",
+      "dev": true
+    },
+    "@types/google.accounts": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/google.accounts/-/google.accounts-0.0.7.tgz",
+      "integrity": "sha512-AAA2+/s/Oa9ETgaWY6JM2P3h8RiQ1FkdyI7QYKMY3hbIkwGbjEBLX0L6FpazVxHnq68ruDyl8Fi5v0tEwSyfeg==",
+      "dev": true
     },
     "@types/http-proxy": {
       "version": "1.17.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "private": true,
   "dependencies": {
-    "@abacritt/angularx-social-login": "^1.2.5",
     "@angular/animations": "^14.2.0",
     "@angular/cdk": "^14.2.5",
     "@angular/common": "^14.2.0",
@@ -22,7 +21,6 @@
     "@angular/platform-browser": "^14.2.0",
     "@angular/platform-browser-dynamic": "^14.2.0",
     "@angular/router": "^14.2.0",
-    "angularx-social-login": "^4.1.0",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
@@ -32,6 +30,8 @@
     "@angular/cli": "~14.2.4",
     "@angular/compiler-cli": "^14.2.0",
     "@types/jasmine": "~4.0.0",
+    "@types/google-one-tap": "^1.2.2",
+    "@types/google.accounts": "0.0.7",
     "autoprefixer": "^10.4.12",
     "jasmine-core": "~4.3.0",
     "karma": "~6.4.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -58,29 +58,6 @@ import { StepperFormStepComponent } from './stepper-forms/stepper-form-step/step
     MatTooltipModule,
     BrowserAnimationsModule
   ],
-  providers: [
-    {
-      provide: 'SocialAuthServiceConfig',
-      useValue: {
-        autoLogin: true,
-        providers: [
-          {
-            id: GoogleLoginProvider.PROVIDER_ID,
-            provider: new GoogleLoginProvider(
-              '338640576133-u9oi7ob3pvldoapfhpm7025j58dbanb6.apps.googleusercontent.com',
-              {
-                scopes: "https://www.googleapis.com/auth/spreadsheets",
-                oneTapEnabled: true,
-              }
-            ),
-          }
-        ],
-        onError: (err: any) => {
-          console.error(err);
-        }
-      } as SocialAuthServiceConfig,
-    }
-  ],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <script src="https://accounts.google.com/gsi/client" onload="console.log('GSI Client Loaded')"></script>
 </head>
 
 <body class="main-background-color mat-typography">

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
   },
   "files": [
     "src/main.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,10 @@
     "lib": [
       "es2020",
       "dom"
+    ],
+    "types": [
+      "google.accounts",
+      "google-one-tap",
     ]
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
## Motivation
With Angular Social Login, there was no way to automatically request a new access token when ours had expired. This resulted in annoying UX flow for long VOD reviews

## Implementation
* Use [GSI Client](https://developers.google.com/identity/oauth2/web/reference/js-reference#google.accounts.oauth2.initTokenClient) directly rather than Angular Social Login
* Use the `expires_in` property returned in order to automatically request a new access token if our current one has expired

## Demo
Here I have artificially shortened the expiration time calculation in order to demonstrate what the workflow would look like if a new token is required to submit a student's notes


https://github.com/braddotcoffee/ValorantStudentTracker/assets/17772186/1890129d-43f4-4204-9a8a-4acb519928b9

